### PR TITLE
fix version check issue

### DIFF
--- a/src/features/versionCheck.ts
+++ b/src/features/versionCheck.ts
@@ -37,13 +37,14 @@ export async function doVersionCheck(notifyNoNewVerFound = false) {
     url: `https://github.com/${repo}/releases/latest`,
   });
 
-  const validUrl = res.finalUrl.includes(`https://github.com/${repo}/releases/tag/`) ? res.finalUrl : undefined;
-
   // TODO: small dialog for "no update found" message?
   const noNewVerFound = () => notifyNoNewVerFound ? showPrompt({ type: "alert", message: t("no_new_version_found") }) : undefined;
 
-  const latestTag = validUrl?.split("/").pop()?.replace(/[a-zA-Z]/g, "");
-
+  let latestTag: string | undefined;
+  const { hostname, pathname } = new URL(res.finalUrl);
+  if(hostname === "github.com" && pathname.startsWith(`/${repo}/releases/tag/`))
+    latestTag = pathname.split("/").pop()?.replace(/[a-zA-Z]/g, "");
+  
   if(!latestTag || !validateStrict(latestTag))
     return await noNewVerFound();
 


### PR DESCRIPTION
Hi Sv443,

Hope you are doing well during these trying times. We previously discussed an issue of a certain pesky dialog rearing it's dastardly head on page load, but only sometimes! (See image attached)

<img width="592" height="272" alt="image" src="https://github.com/user-attachments/assets/36ea54fd-e7ac-47a2-ba5d-f8ebbd0bb02a" />

The current version check code does not account for the hashes that some userscript managers attach to requests internally for correlation reasons (See [this ViolentMonkey release](https://github.com/violentmonkey/violentmonkey/releases/tag/v2.13.1)) and then pass back to scripts. This change instead parses with URL and extracts the pathname, which extracts the hash (See [this Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL)).